### PR TITLE
Fix veeva spec validation

### DIFF
--- a/spec/veeva.yaml
+++ b/spec/veeva.yaml
@@ -36,7 +36,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/delegation/login:
     parameters: []
     post:
@@ -69,7 +71,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/auth:
     parameters: []
     post:
@@ -99,7 +103,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /auth/oauth/session/:{oath_oidc_profile_id}:
     parameters:
       - name: "{oath_oidc_profile_id}"
@@ -135,7 +141,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/:
     parameters: []
     get:
@@ -165,7 +173,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /auth/discovery:
     parameters: []
     post:
@@ -189,7 +199,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/keep-alive:
     parameters: []
     post:
@@ -219,7 +231,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/users/me:
     parameters: []
     get:
@@ -267,7 +281,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     put:
       summary: Update My User
       parameters:
@@ -295,7 +311,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/session:
     parameters: []
     delete:
@@ -326,7 +344,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/directdata/files:
     parameters: []
     get:
@@ -385,7 +405,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/directdata/files/:{name}:
     parameters:
       - name: "{name}"
@@ -424,7 +446,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/query:
     parameters: []
     post:
@@ -466,7 +490,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/query/{{next_page}}:
     parameters: []
     post:
@@ -508,7 +534,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/query/{{previous_page}}:
     parameters: []
     post:
@@ -550,7 +578,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/configuration/:{component_type}:
     parameters:
       - name: "{component_type}"
@@ -585,7 +615,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/configuration/:{component_type_and_record_name}:
     parameters:
       - name: "{component_type_and_record_name}"
@@ -635,7 +667,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/mdl/components/:{component_type_and_record_name}:
     parameters:
       - name: "{component_type_and_record_name}"
@@ -677,7 +711,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/mdl/files:
     parameters: []
     post:
@@ -713,7 +749,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/mdl/components/:{component_type_and_record_name}/files:
     parameters:
       - name: "{component_type_and_record_name}"
@@ -753,7 +791,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/mdl/execute_async:
     parameters: []
     post:
@@ -783,7 +823,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/mdl/execute_async/{job_id}/results:
     parameters:
       - name: job_id
@@ -818,7 +860,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/vobjects/{object_name}/actions/canceldeployment:
     parameters:
       - name: object_name
@@ -853,7 +897,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/mdl/execute:
     parameters: []
     post:
@@ -883,7 +929,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/components:
     parameters: []
     get:
@@ -913,7 +961,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/components/:{component_type}:
     parameters:
       - name: "{component_type}"
@@ -949,7 +999,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/objects/documents/properties:
     parameters: []
     get:
@@ -979,7 +1031,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/objects/documents/properties/find_common:
     parameters: []
     post:
@@ -1015,7 +1069,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/objects/documents/types:
     parameters: []
     get:
@@ -1045,7 +1101,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/objects/documents/types/:{type}:
     parameters:
       - name: "{type}"
@@ -1081,7 +1139,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/objects/documents/types/:{type}/subtypes/:{subtype}:
     parameters:
       - name: "{type}"
@@ -1123,7 +1183,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/objects/documents/types/:{type}/subtypes/:{subtype}/classifications/:{classification}:
     parameters:
       - name: "{type}"
@@ -1171,7 +1233,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents:
     parameters: []
     get:
@@ -1251,7 +1315,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Create Single Document
       parameters:
@@ -1293,7 +1359,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}:
     parameters:
       - name: "{doc_id}"
@@ -1329,7 +1397,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     put:
       summary: Update Single Document
       parameters:
@@ -1377,7 +1447,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Create Single Document Version
       parameters:
@@ -1419,7 +1491,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Delete Single Document
       parameters:
@@ -1447,7 +1521,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/versions:
     parameters:
       - name: "{doc_id}"
@@ -1483,7 +1559,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}:
     parameters:
       - name: "{doc_id}"
@@ -1531,7 +1609,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     put:
       summary: Update Document Version
       parameters:
@@ -1579,7 +1659,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Delete Single Document Version
       parameters:
@@ -1607,7 +1689,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/file:
     parameters:
       - name: "{doc_id}"
@@ -1652,7 +1736,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}/file:
     parameters:
       - name: "{doc_id}"
@@ -1700,7 +1786,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}/thumbnail:
     parameters:
       - name: "{doc_id}"
@@ -1748,7 +1836,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/batch:
     parameters: []
     post:
@@ -1798,7 +1888,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     put:
       summary: Update Multiple Documents
       parameters:
@@ -1846,7 +1938,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Delete Multiple Documents
       parameters:
@@ -1886,7 +1980,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/batch/actions/reclassify:
     parameters: []
     put:
@@ -1937,7 +2033,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/versions/batch:
     parameters: []
     post:
@@ -1994,7 +2092,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Delete Multiple Document Versions
       parameters:
@@ -2034,7 +2134,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/deletions/documents:
     parameters: []
     get:
@@ -2090,7 +2192,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/objects/documents/lock:
     parameters: []
     get:
@@ -2120,7 +2224,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/lock:
     parameters:
       - name: "{doc_id}"
@@ -2156,7 +2262,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     get:
       summary: Retrieve Document Lock
       parameters:
@@ -2184,7 +2292,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Delete Document Lock
       parameters:
@@ -2212,7 +2322,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/batch/lock:
     parameters: []
     delete:
@@ -2248,7 +2360,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/renditions:
     parameters:
       - name: "{doc_id}"
@@ -2284,7 +2398,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}/renditions:
     parameters:
       - name: "{doc_id}"
@@ -2332,7 +2448,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/renditions/:{rendition_type}:
     parameters:
       - name: "{doc_id}"
@@ -2382,7 +2500,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Add Single Document Rendition
       parameters:
@@ -2416,7 +2536,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     put:
       summary: Replace Document Rendition
       parameters:
@@ -2450,7 +2572,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Delete Single Document Rendition
       parameters:
@@ -2478,7 +2602,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}/renditions/:{rendition_type}:
     parameters:
       - name: "{doc_id}"
@@ -2532,7 +2658,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Upload Document Version Rendition
       parameters:
@@ -2566,7 +2694,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     put:
       summary: Replace Document Version Rendition
       parameters:
@@ -2600,7 +2730,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Delete Document Version Rendition
       parameters:
@@ -2628,7 +2760,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/renditions/batch:
     parameters: []
     post:
@@ -2695,7 +2829,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Delete Multiple Document Renditions
       parameters:
@@ -2729,7 +2865,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/batch/actions/rerender:
     parameters: []
     post:
@@ -2765,7 +2903,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/attachments:
     parameters:
       - name: "{doc_id}"
@@ -2801,7 +2941,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Create Document Attachment
       parameters:
@@ -2835,7 +2977,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/version/:{major_version}/:{minor_version}/attachments:
     parameters:
       - name: "{doc_id}"
@@ -2883,7 +3027,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/attachments/:{attachment_id}/versions:
     parameters:
       - name: "{doc_id}"
@@ -2925,7 +3071,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}/attachments/:{attachment_id}/versions/:{attachment_version}:
     parameters:
       - name: "{doc_id}"
@@ -2987,7 +3135,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/attachments/:{attachment_id}:
     parameters:
       - name: "{doc_id}"
@@ -3029,7 +3179,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Delete Single Document Attachment
       parameters:
@@ -3057,7 +3209,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     put:
       summary: Update Document Attachment Description
       parameters:
@@ -3091,7 +3245,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/attachments/:{attachment_id}/versions/:{attachment_version}:
     parameters:
       - name: "{doc_id}"
@@ -3139,7 +3295,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Delete Single Document Attachment Version
       parameters:
@@ -3167,7 +3325,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Restore Document Attachment Version
       parameters:
@@ -3203,7 +3363,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/attachments/:{attachment_id}/file:
     parameters:
       - name: "{doc_id}"
@@ -3245,7 +3407,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/attachments/:{attachment_id}/versions/:{attachment_version}/file:
     parameters:
       - name: "{doc_id}"
@@ -3293,7 +3457,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}/attachments/:{attachment_id}/versions/:{attachment_version}/file:
     parameters:
       - name: "{doc_id}"
@@ -3353,7 +3519,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/attachments/file:
     parameters:
       - name: "{doc_id}"
@@ -3389,7 +3557,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/:{major_version}/:{minor_version}/attachments/file:
     parameters:
       - name: "{doc_id}"
@@ -3437,7 +3607,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/attachments/batch:
     parameters: []
     delete:
@@ -3473,7 +3645,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Create Multiple Document Attachments
       parameters:
@@ -3507,7 +3681,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     put:
       summary: Update Multiple Document Attachment Descriptions
       parameters:
@@ -3541,7 +3717,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/objects/documents/annotations/types/:{annotation_type}:
     parameters:
       - name: "{annotation_type}"
@@ -3605,7 +3783,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/objects/documents/annotations/placemarks/types/:{placemark_type}:
     parameters:
       - name: "{placemark_type}"
@@ -3641,7 +3821,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/objects/documents/annotations/references/types/:{reference_type}:
     parameters:
       - name: "{reference_type}"
@@ -3676,7 +3858,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/annotations/batch:
     parameters: []
     post:
@@ -3720,7 +3904,9 @@ paths:
             type: string
             minLength: 0
             maxLength: 0
-      responses: {}
+      responses:
+        "200":
+          description: Success
     put:
       summary: Update Annotations
       parameters:
@@ -3754,7 +3940,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Delete Annotations
       parameters:
@@ -3788,7 +3976,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/annotations/replies/batch:
     parameters: []
     post:
@@ -3824,7 +4014,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}/annotations:
     parameters:
       - name: "{doc_id}"
@@ -3933,7 +4125,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}/annotations/:{annotation_id}:
     parameters:
       - name: "{doc_id}"
@@ -3989,7 +4183,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}/annotations/:{annotation_id}/replies:
     parameters:
       - name: "{doc_id}"
@@ -4045,7 +4241,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/annotations/file:
     parameters:
       - name: "{doc_id}"
@@ -4081,7 +4279,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Import Document Annotations from PDF
       parameters:
@@ -4115,7 +4315,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}/annotations/file:
     parameters:
       - name: "{doc_id}"
@@ -4163,7 +4365,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Import Document Version Annotations from PDF
       parameters:
@@ -4197,7 +4401,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/anchors:
     parameters:
       - name: "{doc_id}"
@@ -4233,7 +4439,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}/doc-export-annotations-to-csv:
     parameters:
       - name: "{doc_id}"
@@ -4281,7 +4489,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}/export-video-annotations:
     parameters:
       - name: "{doc_id}"
@@ -4333,7 +4543,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/objects/documents/types/:{type}/relationships:
     parameters:
       - name: "{type}"
@@ -4369,7 +4581,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}/relationships:
     parameters:
       - name: "{doc_id}"
@@ -4417,7 +4631,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Create Single Document Relationship
       parameters:
@@ -4451,7 +4667,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/relationships/batch:
     parameters: []
     post:
@@ -4487,7 +4705,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Delete Multiple Document Relationships
       parameters:
@@ -4521,7 +4741,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}/relationships/:{relationship_id}:
     parameters:
       - name: "{doc_id}"
@@ -4575,7 +4797,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Delete Single Document Relationship
       parameters:
@@ -4603,7 +4827,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/batch/actions/fileextract:
     parameters: []
     post:
@@ -4666,7 +4892,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/versions/batch/actions/fileextract:
     parameters: []
     post:
@@ -4720,7 +4948,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/batch/actions/fileextract/:{job_id}/results:
     parameters:
       - name: "{job_id}"
@@ -4758,7 +4988,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/objects/documents/events:
     parameters: []
     get:
@@ -4788,7 +5020,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/objects/documents/events/:{event_type}/types/:{event_subtype}:
     parameters:
       - name: "{event_type}"
@@ -4830,7 +5064,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}/events:
     parameters:
       - name: "{doc_id}"
@@ -4884,7 +5120,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/events:
     parameters:
       - name: "{doc_id}"
@@ -4920,7 +5158,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/objects/documents/templates:
     parameters: []
     get:
@@ -4950,7 +5190,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/templates:
     parameters: []
     get:
@@ -4980,7 +5222,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Create Single Document Template
       parameters:
@@ -5014,7 +5258,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     put:
       summary: Update Multiple Document Templates
       parameters:
@@ -5048,7 +5294,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/templates/:{template_name}:
     parameters:
       - name: "{template_name}"
@@ -5084,7 +5332,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     put:
       summary: Update Single Document Template
       parameters:
@@ -5112,7 +5362,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Delete Basic Document Template
       parameters:
@@ -5140,7 +5392,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/templates/:{template_name}/file:
     parameters:
       - name: "{template_name}"
@@ -5176,7 +5430,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/query/documents/relationships/document_signature__sysr:
     parameters: []
     get:
@@ -5206,7 +5462,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/query/archived_documents/relationships/document_signature__sysr:
     parameters: []
     get:
@@ -5236,7 +5494,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/tokens:
     parameters: []
     post:
@@ -5272,7 +5532,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/binders/:{binder_id}:
     parameters:
       - name: "{binder_id}"
@@ -5316,7 +5578,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Create Binder Version
       parameters:
@@ -5344,7 +5608,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     put:
       summary: Update Binder
       parameters:
@@ -5378,7 +5644,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Delete Binder
       parameters:
@@ -5406,7 +5674,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/binders/:{binder_id}/versions:
     parameters:
       - name: "{binder_id}"
@@ -5442,7 +5712,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/binders/:{binder_id}/versions/:{major_version}/:{minor_version}:
     parameters:
       - name: "{binder_id}"
@@ -5490,7 +5762,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     put:
       summary: Update Binder Version
       parameters:
@@ -5524,7 +5798,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Delete Binder Version
       parameters:
@@ -5552,7 +5828,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/binders:
     parameters: []
     post:
@@ -5600,7 +5878,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/binders/:{binder_id}/actions:
     parameters:
       - name: "{binder_id}"
@@ -5642,7 +5922,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/binders/:{binder_id}/actions/export:
     parameters:
       - name: "{binder_id}"
@@ -5720,7 +6002,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/binders/:{binder_id}/versions/:{major_version}/:{minor_version}/actions/export:
     parameters:
       - name: "{binder_id}"
@@ -5810,7 +6094,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/binders/actions/export/:{job_id}/results:
     parameters:
       - name: "{job_id}"
@@ -5848,7 +6134,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/binders/:{binder_id}/versions/:{major_version}/:{minor_version}/relationships/:{relationship_id}:
     parameters:
       - name: "{binder_id}"
@@ -5902,7 +6190,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Delete Binder Relationship
       parameters:
@@ -5930,7 +6220,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/binders/:{binder_id}/versions/:{major_version}/:{minor_version}/relationships:
     parameters:
       - name: "{binder_id}"
@@ -5984,7 +6276,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/binders/:{binder_id}/sections/:{section_id}:
     parameters:
       - name: "{binder_id}"
@@ -6026,7 +6320,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Delete Binder Section
       parameters:
@@ -6060,7 +6356,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/binders/:{binder_id}/versions/:{major_version}/:{minor_version}/sections/:{section_id}:
     parameters:
       - name: "{binder_id}"
@@ -6117,7 +6415,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/binders/:{binder_id}/sections:
     parameters:
       - name: "{binder_id}"
@@ -6159,7 +6459,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/binders/:{binder_id}/sections/:{node_id}:
     parameters:
       - name: "{binder_id}"
@@ -6207,7 +6509,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/binders/:{binder_id}/documents:
     parameters:
       - name: "{binder_id}"
@@ -6249,7 +6553,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/binders/:{binder_id}/documents/:{section_id}:
     parameters:
       - name: "{binder_id}"
@@ -6297,7 +6603,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Remove Document from Binder
       parameters:
@@ -6325,7 +6633,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/objects/binders/templates:
     parameters: []
     get:
@@ -6355,7 +6665,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/objects/binders/templates/bindernodes:
     parameters: []
     get:
@@ -6385,7 +6697,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/binders/templates:
     parameters: []
     get:
@@ -6415,7 +6729,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Create Binder Template
       parameters:
@@ -6449,7 +6765,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     put:
       summary: Update Binder Template
       parameters:
@@ -6483,7 +6801,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/binders/templates/:{template_name}:
     parameters:
       - name: "{template_name}"
@@ -6519,7 +6839,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Delete Binder Template
       parameters:
@@ -6547,7 +6869,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/binders/templates/:{template_name}/bindernodes:
     parameters:
       - name: "{template_name}"
@@ -6583,7 +6907,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Create Binder Template Node
       parameters:
@@ -6617,7 +6943,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     put:
       summary: Replace Binder Template Nodes
       parameters:
@@ -6651,7 +6979,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/binders/:{binder_id}/binding_rule:
     parameters:
       - name: "{binder_id}"
@@ -6693,7 +7023,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/binders/:{binder_id}/sections/:{node_id}/binding_rule:
     parameters:
       - name: "{binder_id}"
@@ -6741,7 +7073,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/binders/:{binder_id}/documents/:{node_id}/binding_rule:
     parameters:
       - name: "{binder_id}"
@@ -6789,7 +7123,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/configuration/Objecttype:
     parameters: []
     get:
@@ -6819,7 +7155,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/configuration/:{object_name_and_object_type}:
     parameters:
       - name: "{object_name_and_object_type}"
@@ -6866,7 +7204,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobjects/:{object_name}/actions/changetype:
     parameters:
       - name: "{object_name}"
@@ -6908,7 +7248,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobjects/:{object_name}/:{id}/roles/:{role_name}:
     parameters:
       - name: "{object_name}"
@@ -6958,7 +7300,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobjects/:{object_name}/roles:
     parameters:
       - name: "{object_name}"
@@ -7000,7 +7344,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Remove Users & Groups from Roles on Object Records
       parameters:
@@ -7034,7 +7380,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/vobjects/:{object_name}:
     parameters:
       - name: "{object_name}"
@@ -7072,7 +7420,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobjects/:{object_name}/:{object_record_id}/attachments:
     parameters:
       - name: "{object_name}"
@@ -7116,7 +7466,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Create Object Record Attachment
       parameters:
@@ -7150,7 +7502,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobjects/:{object_name}/:{object_record_id}/attachments/:{attachment_id}:
     parameters:
       - name: "{object_name}"
@@ -7200,7 +7554,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     put:
       summary: Update Object Record Attachment Description
       parameters:
@@ -7234,7 +7590,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Delete Object Record Attachment
       parameters:
@@ -7268,7 +7626,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobjects/:{object_name}/:{object_record_id}/attachments/:{attachment_id}/versions:
     parameters:
       - name: "{object_name}"
@@ -7318,7 +7678,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobjects/:{object_name}/:{object_record_id}/attachments/:{attachment_id}/versions/:{attachment_version}:
     parameters:
       - name: "{object_name}"
@@ -7374,7 +7736,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Restore Object Record Attachment Version
       parameters:
@@ -7414,7 +7778,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Delete Object Record Attachment Version
       parameters:
@@ -7442,7 +7808,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobjects/:{object_name}/:{object_record_id}/attachments/:{attachment_id}/versions/:{attachment_version}/file:
     parameters:
       - name: "{object_name}"
@@ -7497,7 +7865,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobjects/:{object_name}/:{object_record_id}/attachments/file:
     parameters:
       - name: "{object_name}"
@@ -7541,7 +7911,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobjects/:{object_name}/attachments/batch:
     parameters:
       - name: "{object_name}"
@@ -7585,7 +7957,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     put:
       summary: Update Multiple Object Record Attachment Descriptions
       parameters:
@@ -7619,7 +7993,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Delete Multiple Object Record Attachments
       parameters:
@@ -7661,7 +8037,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/vobjects/{object_name}/page_layouts:
     parameters:
       - name: object_name
@@ -7696,7 +8074,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/vobjects/{object_name}/page_layouts/{layout_name}:
     parameters:
       - name: object_name
@@ -7738,7 +8118,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobjects/:{object_name}/actions/merge:
     parameters:
       - name: "{object_name}"
@@ -7782,7 +8164,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
       requestBody:
         content:
           application/json:
@@ -7833,7 +8217,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobjects/merges/:{job_id}/results:
     parameters:
       - name: "{job_id}"
@@ -7872,7 +8258,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobjects/merges/:{job_id}/log:
     parameters:
       - name: "{job_id}"
@@ -7911,7 +8299,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobjects/:{object_name}/:{object_record_id}/attachment_fields/:{attachment_field_name}/file:
     parameters:
       - name: "{object_name}"
@@ -7959,7 +8349,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Update Attachment Field File
       parameters:
@@ -7987,7 +8379,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobjects/:{object_name}/:{object_record_id}/attachment_fields/file:
     parameters:
       - name: "{object_name}"
@@ -8029,7 +8423,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobjects/:{object_name}/actions/recalculaterollups:
     parameters:
       - name: "{object_name}"
@@ -8067,7 +8463,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     get:
       summary: Retrieve Roll-up Field Recalculation Status
       parameters:
@@ -8095,7 +8493,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/vobjects/{object_name}:
     parameters:
       - name: object_name
@@ -8142,7 +8542,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/vobjects/{object_name}/fields/{object_field_name}:
     parameters:
       - name: object_name
@@ -8195,7 +8597,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/vobjects:
     parameters: []
     get:
@@ -8234,7 +8638,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobjects/{object_name}:
     parameters:
       - name: object_name
@@ -8280,7 +8686,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobjects/:{object_name}/:{object_record_id}:
     parameters:
       - name: "{object_name}"
@@ -8324,7 +8732,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobjects/:{object_name}:
     parameters:
       - name: "{object_name}"
@@ -8403,7 +8813,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     put:
       summary: Update Object Records
       parameters:
@@ -8462,7 +8874,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Delete Object Records
       parameters:
@@ -8498,7 +8912,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobjects/:{object_name}/:{object_record_id}/actions/cascadedelete:
     parameters:
       - name: "{object_name}"
@@ -8542,7 +8958,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobjects/cascadedelete/results/:{object_name}/:{job_status}/:{job_id}:
     parameters:
       - name: "{object_name}"
@@ -8590,7 +9008,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobjects/:{object_name}/:{object_record_id}/actions/deepcopy:
     parameters:
       - name: "{object_name}"
@@ -8640,7 +9060,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobjects/deepcopy/results/:{object_name}/:{job_status}/:{job_id}:
     parameters:
       - name: "{object_name}"
@@ -8692,7 +9114,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/deletions/vobjects/:{object_name}:
     parameters:
       - name: "{object_name}"
@@ -8730,7 +9154,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/limits:
     parameters: []
     get:
@@ -8760,7 +9186,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobjects/:{object_name}/actions/updatecorporatecurrency:
     parameters:
       - name: "{object_name}"
@@ -8804,7 +9232,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{id}/roles:
     parameters:
       - name: "{id}"
@@ -8839,7 +9269,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Assign Users & Groups to Roles on a Single Document
       parameters:
@@ -8873,7 +9305,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{id}/roles/:{role_name}:
     parameters:
       - name: "{id}"
@@ -8915,7 +9349,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/roles/batch:
     parameters: []
     post:
@@ -8951,7 +9387,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Remove Users and Groups from Roles on Multiple Documents & Binders
       parameters:
@@ -8985,7 +9423,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/roles/:{role_name_and_user_or_group}/:{id}:
     parameters:
       - name: "{doc_id}"
@@ -9036,7 +9476,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/binders/:{id}/roles:
     parameters:
       - name: "{id}"
@@ -9071,7 +9513,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Assign Users & Groups to Roles on a Single Binder
       parameters:
@@ -9105,7 +9549,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/binders/:{id}/roles/:{role_name}:
     parameters:
       - name: "{id}"
@@ -9147,7 +9593,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/binders/:{binder_id}/roles/:{role_name_and_user_or_group}/:{id}:
     parameters:
       - name: "{binder_id}"
@@ -9198,7 +9646,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/objectworkflows/tasks:
     parameters: []
     get:
@@ -9297,7 +9747,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/objectworkflows/tasks/:{task_id}:
     parameters:
       - name: "{task_id}"
@@ -9342,7 +9794,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/objectworkflows/tasks/:{task_id}/actions:
     parameters:
       - name: "{task_id}"
@@ -9378,7 +9832,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/objectworkflows/tasks/:{task_id}/actions/:{task_action}:
     parameters:
       - name: "{task_id}"
@@ -9430,7 +9886,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/objectworkflows/tasks/:{task_id}/actions/mdwaccept:
     parameters:
       - name: "{task_id}"
@@ -9472,7 +9930,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/objectworkflows/tasks/:{task_id}/actions/accept:
     parameters:
       - name: "{task_id}"
@@ -9514,7 +9974,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/objectworkflows/tasks/:{task_id}/actions/undoaccept:
     parameters:
       - name: "{task_id}"
@@ -9556,7 +10018,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/objectworkflows/tasks/:{task_id}/actions/mdwcomplete:
     parameters:
       - name: "{task_id}"
@@ -9598,7 +10062,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/objectworkflows/tasks/:{task_id}/actions/complete:
     parameters:
       - name: "{task_id}"
@@ -9640,7 +10106,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/objectworkflows/tasks/:{task_id}/actions/mdwreassign:
     parameters:
       - name: "{task_id}"
@@ -9682,7 +10150,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/objectworkflows/tasks/:{task_id}/actions/reassign:
     parameters:
       - name: "{task_id}"
@@ -9724,7 +10194,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/objectworkflows/tasks/:{task_id}/actions/updateduedate:
     parameters:
       - name: "{task_id}"
@@ -9766,7 +10238,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/objectworkflows/tasks/:{task_id}/actions/cancel:
     parameters:
       - name: "{task_id}"
@@ -9808,7 +10282,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/objectworkflows/tasks/:{task_id}/actions/mdwmanagecontent:
     parameters:
       - name: "{task_id}"
@@ -9850,7 +10326,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/object/workflow/actions:
     parameters: []
     get:
@@ -9880,7 +10358,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/object/workflow/actions/{action}:
     parameters:
       - name: action
@@ -9915,7 +10395,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Initiate Workflow Actions on Multiple Workflows
       parameters:
@@ -9949,7 +10431,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/object/workflow/actions/cancelworkflows:
     parameters: []
     post:
@@ -9985,7 +10469,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/object/workflow/actions/canceltasks:
     parameters: []
     post:
@@ -10021,7 +10507,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/object/workflow/actions/reassigntasks:
     parameters: []
     post:
@@ -10057,7 +10545,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/object/workflow/actions/replaceworkflowowner:
     parameters: []
     post:
@@ -10093,7 +10583,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/objectworkflows:
     parameters: []
     get:
@@ -10200,7 +10692,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/objectworkflows/:{workflow_id}:
     parameters:
       - name: "{workflow_id}"
@@ -10245,7 +10739,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/objectworkflows/:{workflow_id}/actions:
     parameters:
       - name: "{workflow_id}"
@@ -10289,7 +10785,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/objectworkflows/:{workflow_id}/actions/:{workflow_action}:
     parameters:
       - name: "{workflow_id}"
@@ -10331,7 +10829,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Initiate Workflow Action
       parameters:
@@ -10378,7 +10878,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{id}/versions/:{major_version}/:{minor_version}/lifecycle_actions:
     parameters:
       - name: "{id}"
@@ -10428,7 +10930,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/lifecycle_actions:
     parameters: []
     post:
@@ -10464,7 +10968,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{id}/versions/:{major_version}/:{minor_version}/lifecycle_actions/:{name__v}/entry_requirements:
     parameters:
       - name: "{id}"
@@ -10523,7 +11029,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{id}/versions/:{major_version}/:{minor_version}/lifecycle_actions/:{name__v}:
     parameters:
       - name: "{id}"
@@ -10587,7 +11095,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/actions/:{lifecycle_and_state_and_action}/:{job_id}/results:
     parameters:
       - name: "{lifecycle_and_state_and_action}"
@@ -10633,7 +11143,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/lifecycle_actions/:{user_action_name}:
     parameters:
       - name: "{user_action_name}"
@@ -10677,7 +11189,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/binders/:{id}/versions/:{major_version}/:{minor_version}/lifecycle_actions:
     parameters:
       - name: "{id}"
@@ -10727,7 +11241,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/binders/lifecycle_actions:
     parameters: []
     post:
@@ -10763,7 +11279,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/binders/:{id}/versions/:{major_version}/:{minor_version}/lifecycle_actions/:{name__v}/entry_requirements:
     parameters:
       - name: "{id}"
@@ -10822,7 +11340,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/binders/:{id}/versions/:{major_version}/:{minor_version}/lifecycle_actions/:{name__v}:
     parameters:
       - name: "{id}"
@@ -10886,7 +11406,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/binders/lifecycle_actions/:{user_action_name}:
     parameters:
       - name: "{user_action_name}"
@@ -10930,7 +11452,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/configuration/role_assignment_rule:
     parameters: []
     get:
@@ -11016,7 +11540,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Create Lifecycle Role Assignment Override Rules
       parameters:
@@ -11050,7 +11576,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     put:
       summary: Update Lifecycle Role Assignment Rules (Default & Override)
       parameters:
@@ -11084,7 +11612,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Delete Lifecycle Role Assignment Override Rules
       parameters:
@@ -11112,7 +11642,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/actions:
     parameters: []
     get:
@@ -11151,7 +11683,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/actions/:{workflow_name}:
     parameters:
       - name: "{workflow_name}"
@@ -11196,7 +11730,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Initiate Document Workflow
       parameters:
@@ -11230,7 +11766,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobjects/:{object_name}/:{object_record_id}/actions:
     parameters:
       - name: "{object_name}"
@@ -11281,7 +11819,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobjects/:{object_name}/:{object_record_id}/actions/:{action_name}:
     parameters:
       - name: "{object_name}"
@@ -11333,7 +11873,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Initiate Object Action on a Single Record
       parameters:
@@ -11367,7 +11909,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobjects/:{object_name}/actions/:{action_name}:
     parameters:
       - name: "{object_name}"
@@ -11419,7 +11963,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/objectworkflows/actions:
     parameters: []
     get:
@@ -11449,7 +11995,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/objectworkflows/actions/{workflow_name}:
     parameters:
       - name: workflow_name
@@ -11478,7 +12026,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Initiate Multi-Record Workflow
       parameters:
@@ -11512,7 +12062,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/users:
     parameters: []
     post:
@@ -11548,7 +12100,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     put:
       summary: Update Multiple Users
       parameters:
@@ -11582,7 +12136,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/users/:{id}:
     parameters:
       - name: "{id}"
@@ -11620,7 +12176,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     get:
       summary: Retrieve User
       parameters:
@@ -11666,7 +12224,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/objects/users:
     parameters: []
     get:
@@ -11696,7 +12256,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/users/:
     parameters: []
     get:
@@ -11750,7 +12312,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/users/:{user_id}:
     parameters:
       - name: "{user_id}"
@@ -11795,7 +12359,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/users/me/password:
     parameters: []
     post:
@@ -11831,7 +12397,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/users/:{user_id}/vault_membership/:{vault_id}:
     parameters:
       - name: "{user_id}"
@@ -11881,7 +12449,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/licenses:
     parameters: []
     get:
@@ -11911,7 +12481,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/users/:{id}/permissions:
     parameters:
       - name: "{id}"
@@ -11958,7 +12530,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/users/me/permissions:
     parameters: []
     get:
@@ -11997,7 +12571,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/scim/v2/ServiceProviderConfig:
     parameters: []
     get:
@@ -12027,7 +12603,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/scim/v2/Schemas:
     parameters: []
     get:
@@ -12057,7 +12635,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/scim/v2/Schemas/:{id}:
     parameters:
       - name: "{id}"
@@ -12095,7 +12675,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/scim/v2/ResourceTypes:
     parameters: []
     get:
@@ -12125,7 +12707,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/scim/v2/ResourceTypes/:{type}:
     parameters:
       - name: "{type}"
@@ -12164,7 +12748,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/scim/v2/Users:
     parameters: []
     get:
@@ -12270,7 +12856,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Create User with SCIM
       parameters:
@@ -12304,7 +12892,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/scim/v2/Users/:{id}:
     parameters:
       - name: "{id}"
@@ -12371,7 +12961,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     put:
       summary: Update User with SCIM
       parameters:
@@ -12405,7 +12997,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/scim/v2/Me:
     parameters: []
     get:
@@ -12456,7 +13050,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     put:
       summary: Update Current User with SCIM
       parameters:
@@ -12511,7 +13107,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/scim/v2/:{type}:
     parameters:
       - name: "{type}"
@@ -12617,7 +13215,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/scim/v2/:{type}/:{id}:
     parameters:
       - name: "{type}"
@@ -12686,7 +13286,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/objects/groups:
     parameters: []
     get:
@@ -12716,7 +13318,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/groups:
     parameters: []
     get:
@@ -12757,7 +13361,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: "Create Group "
       parameters:
@@ -12791,7 +13397,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/groups/auto:
     parameters: []
     get:
@@ -12840,7 +13448,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/groups/:{group_id}:
     parameters:
       - name: "{group_id}"
@@ -12888,7 +13498,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     put:
       summary: Update Group
       parameters:
@@ -12922,7 +13534,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Delete Group
       parameters:
@@ -12950,7 +13564,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/picklists:
     parameters: []
     get:
@@ -12980,7 +13596,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/picklists/:{picklist_name}:
     parameters:
       - name: "{picklist_name}"
@@ -13018,7 +13636,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Create Picklist Values
       parameters:
@@ -13052,7 +13672,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     put:
       summary: Update Picklist Value Label
       parameters:
@@ -13086,7 +13708,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/picklists/:{picklist_name}/:{picklist_value_name}:
     parameters:
       - name: "{picklist_name}"
@@ -13138,7 +13762,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Inactivate Picklist Value
       parameters:
@@ -13166,7 +13792,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobjects/edl_item__v/actions/createplaceholder:
     parameters: []
     post:
@@ -13202,7 +13830,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/composites/trees/{edl_hierarchy_or_template}:
     parameters:
       - name: edl_hierarchy_or_template
@@ -13243,7 +13873,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/composites/trees/{edl_hierarchy_or_template}/actions/listnodes:
     parameters:
       - name: edl_hierarchy_or_template
@@ -13285,7 +13917,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/composites/trees/edl_hierarchy__v/:{parent_node_id}/children:
     parameters:
       - name: "{parent_node_id}"
@@ -13327,7 +13961,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     put:
       summary: Update Node Order
       parameters:
@@ -13361,7 +13997,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/edl_matched_documents/batch/actions/add:
     parameters: []
     post:
@@ -13397,7 +14035,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/edl_matched_documents/batch/actions/remove:
     parameters: []
     post:
@@ -13433,7 +14073,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/objects/securitypolicies:
     parameters: []
     get:
@@ -13463,7 +14105,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/securitypolicies:
     parameters: []
     get:
@@ -13493,7 +14137,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/securitypolicies/:{security_policy_name}:
     parameters:
       - name: "{security_policy_name}"
@@ -13531,7 +14177,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/domain:
     parameters: []
     get:
@@ -13577,7 +14225,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/domains:
     parameters: []
     get:
@@ -13613,7 +14263,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/package:
     parameters: []
     post:
@@ -13643,7 +14295,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     put:
       summary: Import Package
       parameters:
@@ -13677,7 +14331,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobject/vault_package__v/:{package_id}/actions/deploy:
     parameters:
       - name: "{package_id}"
@@ -13721,7 +14377,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobject/vault_package__v/:{package_id}/actions/deploy/results:
     parameters:
       - name: "{package_id}"
@@ -13759,7 +14417,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobjects/outbound_package__v/:{package_id}/dependencies:
     parameters:
       - name: "{package_id}"
@@ -13797,7 +14457,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/query/components:
     parameters: []
     post:
@@ -13833,7 +14495,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/vault/actions/compare:
     parameters: []
     post:
@@ -13863,7 +14527,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/vault/actions/configreport:
     parameters: []
     post:
@@ -13893,7 +14559,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/package/actions/validate:
     parameters: []
     post:
@@ -13923,7 +14591,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/configuration_mode/actions/enable:
     parameters: []
     post:
@@ -13958,7 +14628,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/configuration_mode/actions/disable:
     parameters: []
     post:
@@ -13993,7 +14665,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/sandbox/actions/buildproduction:
     parameters: []
     post:
@@ -14029,7 +14703,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/sandbox/actions/promoteproduction:
     parameters: []
     post:
@@ -14065,7 +14741,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/sandbox/snapshot:
     parameters: []
     post:
@@ -14101,7 +14779,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     get:
       summary: Retrieve Sandbox Snapshots
       parameters:
@@ -14129,7 +14809,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/sandbox/snapshot/:{api_name}:
     parameters:
       - name: "{api_name}"
@@ -14167,7 +14849,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/sandbox/snapshot/:{api_name}/actions/update:
     parameters:
       - name: "{api_name}"
@@ -14205,7 +14889,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/sandbox/snapshot/:{api_name}/actions/upgrade:
     parameters:
       - name: "{api_name}"
@@ -14243,7 +14929,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/sandbox:
     parameters: []
     get:
@@ -14273,7 +14961,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Create or Refresh Sandbox
       parameters:
@@ -14307,7 +14997,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/sandbox/{vault_id}:
     parameters:
       - name: vault_id
@@ -14342,7 +15034,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/sandbox/actions/recheckusage:
     parameters: []
     post:
@@ -14378,7 +15072,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/sandbox/batch/changesize:
     parameters: []
     post:
@@ -14414,7 +15110,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/sandbox/entitlements/set:
     parameters: []
     post:
@@ -14450,7 +15148,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/sandbox/:{vault_id}/actions/refresh:
     parameters:
       - name: "{vault_id}"
@@ -14492,7 +15192,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/sandbox/:{name}:
     parameters:
       - name: "{name}"
@@ -14530,7 +15232,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/audittrail:
     parameters: []
     get:
@@ -14560,7 +15264,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/metadata/audittrail/:{audit_trail_type}:
     parameters:
       - name: "{audit_trail_type}"
@@ -14598,7 +15304,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/audittrail/:{audit_trail_type}:
     parameters:
       - name: "{audit_trail_type}"
@@ -14719,7 +15427,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/objects/documents/:{doc_id}/audittrail:
     parameters:
       - name: "{doc_id}"
@@ -14812,7 +15522,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/vobjects/:{object_name}/:{object_record_id}/audittrail:
     parameters:
       - name: "{object_name}"
@@ -14911,7 +15623,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/logs/code/debug:
     parameters: []
     get:
@@ -14960,7 +15674,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Create Debug Log
       parameters:
@@ -14994,7 +15710,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/logs/code/debug/:{id}:
     parameters:
       - name: "{id}"
@@ -15030,7 +15748,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/logs/code/debug/:{id}/files:
     parameters:
       - name: "{id}"
@@ -15066,7 +15786,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/logs/code/debug/:{id}/actions/reset:
     parameters:
       - name: "{id}"
@@ -15102,7 +15824,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Delete Debug Log
       parameters:
@@ -15130,7 +15854,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/code/profiler:
     parameters: []
     get:
@@ -15160,7 +15886,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Create Profiling Session
       parameters:
@@ -15194,7 +15922,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/code/profiler/:{session_name}:
     parameters:
       - name: "{session_name}"
@@ -15230,7 +15960,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Delete Profiling Session
       parameters:
@@ -15258,7 +15990,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/code/profiler/:{session_name}/actions/end:
     parameters:
       - name: "{session_name}"
@@ -15294,7 +16028,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/code/profiler/:{session_name}/results:
     parameters:
       - name: "{session_name}"
@@ -15330,7 +16066,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/notifications/histories:
     parameters: []
     get:
@@ -15429,7 +16167,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/logs/api_usage:
     parameters: []
     get:
@@ -15477,7 +16217,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/logs/code/runtime:
     parameters: []
     get:
@@ -15523,7 +16265,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/file_staging/upload:
     parameters: []
     post:
@@ -15553,7 +16297,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/file_staging/upload/{upload_session_id}:
     parameters:
       - name: upload_session_id
@@ -15612,7 +16358,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Commit Upload Session
       parameters:
@@ -15640,7 +16388,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     get:
       summary: Get Upload Session Details
       parameters:
@@ -15668,7 +16418,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Abort Upload Session
       parameters:
@@ -15696,7 +16448,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/file_staging/upload/:
     parameters: []
     get:
@@ -15726,7 +16480,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/file_staging/upload/{upload_session_id}/parts:
     parameters:
       - name: upload_session_id
@@ -15770,7 +16526,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/file_staging/items/{item}:
     parameters:
       - name: item
@@ -15834,7 +16592,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     put:
       summary: Update Folder or File
       parameters:
@@ -15862,7 +16622,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Delete File or Folder
       parameters:
@@ -15899,7 +16661,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/file_staging/items/content/{item}:
     parameters:
       - name: item
@@ -15947,7 +16711,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/file_staging/items:
     parameters: []
     post:
@@ -15983,7 +16749,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/loader/extract:
     parameters: []
     post:
@@ -16019,7 +16787,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/loader/:{job_id}/tasks/:{task_id}/results:
     parameters:
       - name: "{job_id}"
@@ -16061,7 +16831,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/loader/:{job_id}/tasks/:{task_id}/results/renditions:
     parameters:
       - name: "{job_id}"
@@ -16103,7 +16875,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/loader/load:
     parameters: []
     post:
@@ -16139,7 +16913,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/loader/:{job_id}/tasks/:{task_id}/successlog:
     parameters:
       - name: "{job_id}"
@@ -16181,7 +16957,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/loader/:{job_id}/tasks/:{task_id}/failurelog:
     parameters:
       - name: "{job_id}"
@@ -16223,7 +17001,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/messages/:{message_type}/language/:{lang}/actions/export:
     parameters:
       - name: "{message_type}"
@@ -16270,7 +17050,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/messages/:{message_type}/actions/import:
     parameters:
       - name: "{message_type}"
@@ -16308,7 +17090,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/jobs/:{job_id}/summary:
     parameters:
       - name: "{job_id}"
@@ -16346,7 +17130,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/jobs/:{job_id}/errors:
     parameters:
       - name: "{job_id}"
@@ -16384,7 +17170,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/jobs/:{job_id}:
     parameters:
       - name: "{job_id}"
@@ -16420,7 +17208,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/jobs/:{job_id}/tasks:
     parameters:
       - name: "{job_id}"
@@ -16456,7 +17246,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/jobs/histories:
     parameters: []
     get:
@@ -16534,7 +17326,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/jobs/monitors:
     parameters: []
     get:
@@ -16613,7 +17407,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/jobs/start_now/:{job_id}:
     parameters:
       - name: "{job_id}"
@@ -16649,7 +17445,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/queues:
     parameters: []
     get:
@@ -16679,7 +17477,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/queues/:{queue_name}:
     parameters:
       - name: "{queue_name}"
@@ -16715,7 +17515,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/queues/:{queue_name}/actions/disable_delivery:
     parameters:
       - name: "{queue_name}"
@@ -16751,7 +17553,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/queues/:{queue_name}/actions/enable_delivery:
     parameters:
       - name: "{queue_name}"
@@ -16787,7 +17591,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/queues/:{queue_name}/actions/reset:
     parameters:
       - name: "{queue_name}"
@@ -16823,7 +17629,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/code/:{class_name}:
     parameters:
       - name: "{class_name}"
@@ -16859,7 +17667,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Delete Single Source Code File
       parameters:
@@ -16887,7 +17697,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/code/:{class_name}/enable:
     parameters:
       - name: "{class_name}"
@@ -16929,7 +17741,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/code/:{class_name}/disable:
     parameters:
       - name: "{class_name}"
@@ -16971,7 +17785,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/code:
     parameters: []
     put:
@@ -17007,7 +17823,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/vobject/vault_package__v/:{package_id}/actions/validate:
     parameters:
       - name: "{package_id}"
@@ -17046,7 +17864,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/services/certificate/:{cert_id}:
     parameters:
       - name: "{cert_id}"
@@ -17084,7 +17904,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/uicode/distributions:
     parameters: []
     get:
@@ -17114,7 +17936,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     post:
       summary: Add or Replace Single Client Code Distribution
       parameters:
@@ -17148,7 +17972,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/uicode/distributions/:{distribution_name}:
     parameters:
       - name: "{distribution_name}"
@@ -17184,7 +18010,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
     delete:
       summary: Delete Single Client Code Distribution
       parameters:
@@ -17212,7 +18040,9 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
   /api/{{version}}/uicode/distributions/:{distribution_name}/code:
     parameters:
       - name: "{distribution_name}"
@@ -17248,5 +18078,7 @@ paths:
           example: "{{clientId}}"
           schema:
             type: string
-      responses: {}
+      responses:
+        "200":
+          description: Success
 


### PR DESCRIPTION
## Summary
- update `veeva.yaml` to include a default 200 response for each operation

## Testing
- `npx -y swagger-cli validate spec/veeva.yaml`

------
https://chatgpt.com/codex/tasks/task_e_68700c63530c832ca12f1f49b70de022